### PR TITLE
Fix README.md for correct copyright statement.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Demo：1a23.com
 付协议文本如下：
 
 ```
-Copyright (c) Ben Word and Scott Walkinshaw
+Copyright (c) Ben Word, Scott Walkinshaw, Eana Hufwe
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in


### PR DESCRIPTION
Fix README.md for correct copyright statement, the theme author is not included in the copyright statement in MIT license.